### PR TITLE
Add MicroBadger badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 Quick script for examining Docker registry v2 data
 
-[![Docker Stars](https://img.shields.io/docker/stars/lizrice/dockerregistry.svg?maxAge=2592000)]()
+[![Docker Stars](https://img.shields.io/docker/stars/lizrice/dockerregistry.svg?maxAge=2592000)]() [![](https://images.microbadger.com/badges/image/lizrice/dockerregistry.svg)](https://microbadger.com/images/lizrice/dockerregistry "Get your own image badge on microbadger.com")
 
 The Dockerfiles are really just for experiments - don't expect them to do anything useful! 
+ 


### PR DESCRIPTION
We saw your image on Docker Hub at [lizrice/dockerregistry](https://hub.docker.com/r/lizrice/dockerregistry/), and we thought you might like this badge for your GitHub readme showing the image contents.

The badge shows the number of layers and download size of your Docker image, and links to our site where you can see the [contents of each layer](https://microbadger.com/images/lizrice/dockerregistry).

As you're using an automated build it will also show up in your Docker Hub description.

[![](https://images.microbadger.com/badges/image/lizrice/dockerregistry.svg)](https://microbadger.com/images/lizrice/dockerregistry)
